### PR TITLE
Remote mount

### DIFF
--- a/buildkit/.editorconfig
+++ b/buildkit/.editorconfig
@@ -12,11 +12,12 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.go]
-indent_type = tab
+indent_style = tab
 
 [Makefile]
-indent_type = tab
+indent_style = tab
+indent_size = 8
 
-[*.yaml]
+[*.{yaml,yml}]
 indent_size = 2
 indent_style = space

--- a/buildkit/Dockerfile
+++ b/buildkit/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.3
+# syntax=docker/dockerfile:1.4
 
 ARG GOLANG_IMAGE=golang:1.17.8-alpine@sha256:f4ece20984a30d1065b04653bf6781f51ab63421b4b8f011565de0401cfe58d7
 

--- a/buildkit/Makefile
+++ b/buildkit/Makefile
@@ -4,7 +4,7 @@ IMAGE_REFERENCE = ${DOCKER_REG}/goshfile
 DOCKER          = docker
 
 
-all: image build-example run-example save-example
+all: image build-example run-example
 
 .PHONE: test
 test:
@@ -36,8 +36,7 @@ image:
 	@echo ------------------------------------
 	@echo Build buildkit-gosh \(aka frontend\)
 	@echo ------------------------------------
-	${DOCKER} buildx build -f Dockerfile -t ${IMAGE_REFERENCE}:${VERSION} .
-	${DOCKER} push ${IMAGE_REFERENCE}:${VERSION}
+	${DOCKER} buildx build --push -f Dockerfile -t ${IMAGE_REFERENCE}:${VERSION} .
 
 # Examples
 .PHONE: build-example
@@ -66,6 +65,6 @@ public_image:
 	@echo ------------------------------------
 	@echo Build and push public image
 	@echo ------------------------------------
-	go mod vendor
-	${DOCKER} build -f Dockerfile -t teamgosh/goshfile:${VERSION} .
-	${DOCKER} push teamgosh/goshfile:${VERSION}
+	${DOCKER} buildx create --use
+	${DOCKER} buildx build --push --platform linux/amd64,linux/arm64 -f Dockerfile -t teamgosh/goshfile:${VERSION} .
+	${DOCKER} buildx rm

--- a/buildkit/examples/from_gosh/build.sh
+++ b/buildkit/examples/from_gosh/build.sh
@@ -18,7 +18,7 @@ echo
 docker run --rm -ti \
     -v "$(pwd)":/root \
     teamgosh/git-remote-gosh \
-    git clone \
+    clone \
     gosh::net.ton.dev://0:a6af961f2973bb00fe1d3d6cfee2f2f9c89897719c2887b31ef5ac4fd060638f/gosh/example \
     example1
 
@@ -77,6 +77,11 @@ docker run --rm teamgosh/sign-cli sign \
 read -r -p "Check? [y/N]
 " y
 [[ ! "$y" = [yY]* ]] && exit 1
+
+echo
+echo Check "$TARGET_IMAGE"@"$TARGET_IMAGE_SHA"
+echo
+echo
 
 docker run --rm teamgosh/sign-cli check \
     -n "$NETWORKS" \

--- a/buildkit/examples/from_gosh/build.sh
+++ b/buildkit/examples/from_gosh/build.sh
@@ -3,7 +3,7 @@
 TARGET_IMAGE=teamgosh/example1
 NETWORKS="${NETWORKS:-https://gra01.net.everos.dev,https://rbx01.net.everos.dev,https://eri01.net.everos.dev}"
 
-if [[ -z "$WALLET" ]] || [[ -z "$WALLET_PUBLIC" ]] || [[ -z "$WALLET_SECRET" ]] ; then
+if [[ -z "$WALLET" ]] || [[ -z "$WALLET_PUBLIC" ]] || [[ -z "$WALLET_SECRET" ]]; then
     echo "Make sure \$WALLET \$WALLET_PUBLIC \$WALLET_SECRET are set"
     echo "export WALLET=..."
     echo "export WALLET_SECRET=..."
@@ -18,7 +18,9 @@ echo
 docker run --rm -ti \
     -v "$(pwd)":/root \
     teamgosh/git-remote-gosh \
-    git clone gosh::net.ton.dev://0:a6af961f2973bb00fe1d3d6cfee2f2f9c89897719c2887b31ef5ac4fd060638f/gosh/example example1
+    git clone \
+    gosh::net.ton.dev://0:a6af961f2973bb00fe1d3d6cfee2f2f9c89897719c2887b31ef5ac4fd060638f/gosh/example \
+    example1
 
 echo
 echo Clone DONE
@@ -30,15 +32,16 @@ read -r -p "Continue? [y/N]
 [[ ! "$y" = [yY]* ]] && exit 1
 
 echo
-echo Build with GOSH frontend
+echo Build and push with GOSH frontend
 echo
 echo
+
 docker buildx build \
+    --push \
     -f example1/goshfile.yaml \
     --label WALLET_PUBLIC="$WALLET_PUBLIC" \
-    -t $TARGET_IMAGE example1
-
-docker push "$TARGET_IMAGE"
+    -t $TARGET_IMAGE \
+    example1
 
 echo
 echo Build and push DONE
@@ -48,7 +51,6 @@ echo
 read -r -p "Continue? [y/N]
 " y
 [[ ! "$y" = [yY]* ]] && exit 1
-
 
 echo
 echo Sign "$TARGET_IMAGE"
@@ -60,7 +62,7 @@ docker pull "$TARGET_IMAGE"
 TARGET_IMAGE_SHA=$(docker inspect --format='{{index (split (index .RepoDigests 0) "@") 1}}' $TARGET_IMAGE)
 echo TARGET_IMAGE_SHA=\'"$TARGET_IMAGE_SHA"\'
 
-if [[ -z "$TARGET_IMAGE_SHA" ]] ; then
+if [[ -z "$TARGET_IMAGE_SHA" ]]; then
     echo Target image hash not found
     exit
 fi

--- a/buildkit/examples/local_dev/build.sh
+++ b/buildkit/examples/local_dev/build.sh
@@ -11,8 +11,11 @@ case "$1" in
     build)
         docker buildx build \
             --push \
+            --label WALLET_PUBLIC="$WALLET_PUBLIC" \
             -f goshfile.yaml \
             -t "$IMAGE" .
+
+        docker inspect --format '{{ json .Config }}' "$IMAGE"
         ;;
     buildctl)
         buildctl --addr=docker-container://buildkitd build \

--- a/buildkit/hack/git-remote-gosh/Dockerfile
+++ b/buildkit/hack/git-remote-gosh/Dockerfile
@@ -7,6 +7,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     apt-get update -qy
     apt-get install git -qy
 EOF
+ENTRYPOINT [ "git" ]
 
 WORKDIR /app
 COPY gosh gosh

--- a/buildkit/hack/git-remote-gosh/build.sh
+++ b/buildkit/hack/git-remote-gosh/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 PROJECT_ROOT=$(realpath ../../..)
-docker buildx build --push -f Dockerfile -t tesmgosh/git-remote-gosh "$PROJECT_ROOT"
+docker buildx build --push -f Dockerfile -t teamgosh/git-remote-gosh "$PROJECT_ROOT"


### PR DESCRIPTION
- hash experiment
- test buildx
- remove go mod vendor from make
- update constants
- fix tar exclude patterns
- Gosh contracts and git-remote-gosh (#22)
- use buildx
- update publisher exampe
- add remote gosh example
- merge labels from 'buildx' and 'buildctl'
- git-remote-gosh image
- update remote gosh example
